### PR TITLE
Hash main file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ var AddAssetHtmlPlugin = require('add-asset-html-webpack-plugin');
 module.exports = {
     entry: './app.js',
     output: {
-        filename: 'bundle.js',
+        filename: '[name].[chunkhash].js',
         path: path.resolve(__dirname, 'dist')
     },
     plugins: [


### PR DESCRIPTION
Es un cambio pequeño para añadir un hash en el paquete principal y que así no le afecte el caché. Pruébalo por si vieses que afecta al tiempo de compilación o algo, aunque no debería. A mí me ha ido bien.